### PR TITLE
Add Cover arts for listens and feed 

### DIFF
--- a/Listenbrainz.xcodeproj/project.pbxproj
+++ b/Listenbrainz.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BB66C20D2AA0F5DE00BB4CBA /* FeedAdditionalInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB66C20C2AA0F5DE00BB4CBA /* FeedAdditionalInfo.swift */; };
 		BB66C20F2AA0F63800BB4CBA /* FeedMbidMapping.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB66C20E2AA0F63800BB4CBA /* FeedMbidMapping.swift */; };
 		BB66C2112AA0F6C500BB4CBA /* ListensArtist.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB66C2102AA0F6C500BB4CBA /* ListensArtist.swift */; };
+		BB7833642B3F2DB3005D7266 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB7833632B3F2DB3005D7266 /* ImageLoader.swift */; };
 		BBD20D5B2A3C7D57007C0C71 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD20D5A2A3C7D57007C0C71 /* SettingsView.swift */; };
 		BBD28DD12A2F9D9B00AD57C6 /* FeedAlbum.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD28DD02A2F9D9B00AD57C6 /* FeedAlbum.swift */; };
 		BBD28DD32A2F9DC400AD57C6 /* FeedArtist.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBD28DD22A2F9DC400AD57C6 /* FeedArtist.swift */; };
@@ -118,6 +119,7 @@
 		BB66C20C2AA0F5DE00BB4CBA /* FeedAdditionalInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAdditionalInfo.swift; sourceTree = "<group>"; };
 		BB66C20E2AA0F63800BB4CBA /* FeedMbidMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedMbidMapping.swift; sourceTree = "<group>"; };
 		BB66C2102AA0F6C500BB4CBA /* ListensArtist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListensArtist.swift; sourceTree = "<group>"; };
+		BB7833632B3F2DB3005D7266 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		BBD20D5A2A3C7D57007C0C71 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		BBD28DD02A2F9D9B00AD57C6 /* FeedAlbum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAlbum.swift; sourceTree = "<group>"; };
 		BBD28DD22A2F9DC400AD57C6 /* FeedArtist.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedArtist.swift; sourceTree = "<group>"; };
@@ -259,6 +261,7 @@
 			children = (
 				6F842DFA29C650A600DBBC7B /* Constants.swift */,
 				6F155CA92B08E32A005FE042 /* Extensions.swift */,
+				BB7833632B3F2DB3005D7266 /* ImageLoader.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -556,6 +559,7 @@
 				BB2A4F5529EB48CC006933BC /* HomeView.swift in Sources */,
 				BBE9630E2B0560FC00AA4219 /* BrainzPlayerMetadata.swift in Sources */,
 				6F842DCB29C64E3E00DBBC7B /* ListenbrainzApp.swift in Sources */,
+				BB7833642B3F2DB3005D7266 /* ImageLoader.swift in Sources */,
 				BB0586572A2504AD00744FF0 /* Listens.swift in Sources */,
 				BB519BAD2B1DE78200766F01 /* WelcomeView.swift in Sources */,
 				BB519BAF2B1DE95E00766F01 /* UserDetailsView.swift in Sources */,

--- a/Listenbrainz/Model/Feed/FeedTrackMetadata.swift
+++ b/Listenbrainz/Model/Feed/FeedTrackMetadata.swift
@@ -7,20 +7,27 @@
 
 import Foundation
 
-
-// MARK: - TrackMetadata
 struct FeedTrackMetadata: Codable {
-    //let additionalInfo: FeedAdditionalInfo
-    let artistName: String
-   // let mbidMapping: FeedMbidMapping?
-  let releaseName:String?
-   let trackName: String
+  let additionalInfo: FeedAdditionalInfo
+  let artistName: String
+  let releaseName: String?
+  let trackName: String
+  let mbidMapping: FeedMbidMapping?
 
-    enum CodingKeys: String, CodingKey {
-       // case additionalInfo = "additional_info"
-        case artistName = "artist_name"
-      //  case mbidMapping = "mbid_mapping"
-        case releaseName = "release_name"
-        case trackName = "track_name"
+  enum CodingKeys: String, CodingKey {
+    case additionalInfo = "additional_info"
+    case artistName = "artist_name"
+    case releaseName = "release_name"
+    case trackName = "track_name"
+    case mbidMapping = "mbid_mapping"
+  }
+
+  var coverArtURL: URL? {
+    guard let caaReleaseMbid = mbidMapping?.caaReleaseMbid,
+          let caaID = mbidMapping?.caaID else {
+      return nil
     }
+    return URL(string: "https://coverartarchive.org/release/\(caaReleaseMbid)/\(caaID)-250.jpg")
+  }
 }
+

--- a/Listenbrainz/Model/Listens/ListensTrackMetadata.swift
+++ b/Listenbrainz/Model/Listens/ListensTrackMetadata.swift
@@ -27,4 +27,11 @@ struct ListensTrackMetadata: Codable {
         case mbidMapping = "mbid_mapping"
         case brainzplayerMetadata = "brainzplayer_metadata"
     }
+
+  var coverArtURL: URL? {
+        guard let caaReleaseMbid = mbidMapping?.caaReleaseMbid, let caaID = mbidMapping?.caaID else {
+            return nil
+        }
+        return URL(string: "https://coverartarchive.org/release/\(caaReleaseMbid)/\(caaID)-250.jpg")
+    }
 }

--- a/Listenbrainz/UI/Components/TopBar.swift
+++ b/Listenbrainz/UI/Components/TopBar.swift
@@ -17,11 +17,11 @@ struct TopBar: View {
         Image("secondaryIcon")
           .resizable()
           .scaledToFit()
-          .frame(width: 40, height: 40)
+          .frame(width: 30, height: 30)
         Image("primaryIcon")
           .resizable()
           .scaledToFit()
-          .frame(width: 40, height: 40)
+          .frame(width: 30, height: 30)
       }
 
 

--- a/Listenbrainz/UI/Screens/Feed/EventDescriptionView.swift
+++ b/Listenbrainz/UI/Screens/Feed/EventDescriptionView.swift
@@ -7,29 +7,60 @@
 
 import SwiftUI
 
+
 struct EventDescriptionView: View {
-  let event: Event
+    @Environment(\.colorScheme) var colorScheme
+    let event: Event
 
-  var body: some View {
-    Text(eventDescription(for: event))
-      .font(.subheadline)
-      .foregroundColor(.blue)
-  }
-
-  private func eventDescription(for event: Event) -> String {
-    switch event.eventType {
-    case "listen":
-      return "\(event.userName) listened to a track"
-    case "recording_recommendation":
-      return "\(event.userName) recommended a track"
-    case "critiquebrainz_review":
-      return "\(event.userName) reviewed a track"
-    case "recording_pin":
-      return "\(event.userName) pinned a track"
-    case "follow":
-      return "\(event.metadata.userName0!) started following \(event.metadata.userName1!)"
-    default:
-      return "An event occurred"
+    var body: some View {
+        eventDescription(for: event)
+            .font(.subheadline)
+            .foregroundColor(foregroundColor)
     }
-  }
+
+    private var foregroundColor: Color {
+        return colorScheme == .dark ? .white : .black
+    }
+
+    private func eventDescription(for event: Event) -> Text {
+        let usernameText = Text(event.userName)
+            .foregroundColor(.blue)
+
+        switch event.eventType {
+        case "listen":
+            return usernameText
+                + Text(" listened to a track ")
+                .foregroundColor(foregroundColor)
+
+        case "recording_recommendation":
+            return usernameText
+                + Text(" recommended a track ")
+                .foregroundColor(foregroundColor)
+
+        case "critiquebrainz_review":
+            return usernameText
+                + Text(" reviewed a track ")
+                .foregroundColor(foregroundColor)
+
+        case "recording_pin":
+            return usernameText
+                + Text(" pinned a track ")
+                .foregroundColor(foregroundColor)
+
+        case "follow":
+            let username0Text = Text(event.metadata.userName0 ?? "")
+                .foregroundColor(.blue)
+            let username1Text = Text(event.metadata.userName1 ?? "")
+                .foregroundColor(.blue)
+
+            return username0Text
+                + Text(" started following ")
+                .foregroundColor(foregroundColor)
+                + username1Text
+
+        default:
+            return Text("An event occurred")
+                .foregroundColor(foregroundColor)
+        }
+    }
 }

--- a/Listenbrainz/UI/Screens/Listens/SongDetailView.swift
+++ b/Listenbrainz/UI/Screens/Listens/SongDetailView.swift
@@ -1,49 +1,93 @@
-//
-//  SongDetailView.swift
-//  Listenbrainz
-//
-//  Created by Gaurav Bhardwaj on 29/05/23.
-//
-
 import SwiftUI
 
 struct SongDetailView: View {
-  
-  @EnvironmentObject var homeViewModel: HomeViewModel
+    @EnvironmentObject var homeViewModel: HomeViewModel
+    @StateObject private var imageLoader = ImageLoader.shared
+    @State private var isLoading = true
 
+    var body: some View {
+        VStack {
+            List {
+                ForEach(homeViewModel.listens, id: \.recordingMsid) { listen in
+                    HStack {
+                        if let coverArtURL = listen.trackMetadata.coverArtURL {
+                            AsyncImage(
+                                url: coverArtURL,
+                                scale: 0.1,
+                                transaction: Transaction(animation: nil),
+                                content: { phase in
+                                    switch phase {
+                                    case .success(let image):
+                                        image
+                                            .resizable()
+                                            .scaledToFit()
+                                            .frame(width: 50, height: 50)
+                                            .onAppear {
+                                                imageLoader.loadImage(url: coverArtURL) { loadedImage in
+                                                    if let uiImage = loadedImage {
+                                                        ImageCache.shared.insertImage(uiImage, for: coverArtURL)
+                                                    }
+                                                }
+                                            }
 
-  var body: some View {
+                                    default:
+                                        if let cachedImage = ImageCache.shared.image(for: coverArtURL) {
+                                            Image(uiImage: cachedImage)
+                                                .resizable()
+                                                .scaledToFit()
+                                                .frame(width: 50, height: 50)
+                                        } else {
+                                            Image(systemName: "music.note")
+                                                .resizable()
+                                                .renderingMode(.template)
+                                                .foregroundColor(.orange)
+                                                .scaledToFit()
+                                                .frame(width: 50, height: 50)
+                                        }
+                                    }
+                                }
+                            )
+                            .frame(width: 50, height: 50)
+                        } else {
+                            Image(systemName: "music.note")
+                                .resizable()
+                                .renderingMode(.template)
+                                .foregroundColor(.orange)
+                                .scaledToFit()
+                                .frame(width: 50, height: 50)
+                        }
 
-    VStack {
-      List {
-        ForEach(homeViewModel.listens, id: \.recordingMsid) { listen in
-          HStack {
-            Image(systemName: "music.note")
-              .resizable()
-              .renderingMode(.template)
-              .foregroundColor(.orange)
-              .scaledToFit()
-              .frame(height: 22)
-              .padding(4)
-
-            VStack(alignment: .leading) {
-              Text(listen.trackMetadata.trackName)
-                .lineLimit(1)
-                .font(.headline)
-              Text(listen.trackMetadata.artistName)
-                .lineLimit(1)
-                
+                        VStack(alignment: .leading) {
+                            Text(listen.trackMetadata.trackName)
+                                .lineLimit(1)
+                                .font(.headline)
+                            Text(listen.trackMetadata.artistName)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+                .navigationTitle("Listens")
             }
-          }
+            .listStyle(PlainListStyle())
+            .listRowSeparator(.hidden)
+            .listRowInsets(EdgeInsets(top: 0, leading: 36, bottom: 0, trailing: 16))
         }
-
-
-        .navigationTitle("Listens")
-
-
-      }
+        .onAppear {
+            Task {
+                await withTaskGroup(of: Void.self) { group in
+                    for listen in homeViewModel.listens {
+                        if let coverArtURL = listen.trackMetadata.coverArtURL {
+                            group.addTask {
+                                await imageLoader.loadImage(url: coverArtURL) { _ in }
+                            }
+                        }
+                    }
+                    await group.waitForAll()
+                }
+                isLoading = false
+            }
+        }
     }
-  }
-
-
 }
+
+

--- a/Listenbrainz/Utils/ImageLoader.swift
+++ b/Listenbrainz/Utils/ImageLoader.swift
@@ -1,0 +1,54 @@
+//
+//  ImageLoader.swift
+//  Listenbrainz
+//
+//  Created by Gaurav Bhardwaj on 29/12/23.
+//
+
+import SwiftUI
+import Combine
+import Alamofire
+
+
+class ImageCache {
+  static let shared = ImageCache()
+
+  private let cache = NSCache<NSURL, UIImage>()
+
+  func image(for url: URL) -> UIImage? {
+    return cache.object(forKey: url as NSURL)
+  }
+
+  func insertImage(_ image: UIImage, for url: URL) {
+    cache.setObject(image, forKey: url as NSURL)
+  }
+}
+
+class ImageLoader: ObservableObject {
+  static let shared = ImageLoader()
+
+  private var cancellables: Set<AnyCancellable> = []
+
+  @Published var imageCache: [URL: UIImage] = [:]
+
+  func loadImage(url: URL, completion: @escaping (UIImage?) -> Void) {
+    if let cachedImage = imageCache[url] {
+      completion(cachedImage)
+      return
+    }
+
+    AF.request(url).responseData { response in
+      switch response.result {
+      case .success(let data):
+        if let uiImage = UIImage(data: data) {
+          self.imageCache[url] = uiImage
+          completion(uiImage)
+        } else {
+          completion(nil)
+        }
+      case .failure:
+        completion(nil)
+      }
+    }
+  }
+}

--- a/Listenbrainz/ViewModel/FeedViewModel.swift
+++ b/Listenbrainz/ViewModel/FeedViewModel.swift
@@ -9,37 +9,53 @@ import Alamofire
 import Combine
 import Foundation
 
-
 class FeedViewModel: ObservableObject {
-    @Published var feedData: FeedAlbum?
-    @Published var events: [Event] = []
+  @Published var feedData: FeedAlbum?
+  @Published var events: [Event] = []
 
   private var subscriptions: Set<AnyCancellable> = []
   var repository: FeedRepository
 
-
   init(repository: FeedRepository) {
-      self.repository = repository
-
+    self.repository = repository
   }
 
+  func fetchFeedEvents(username: String, userToken: String) {
+    repository.fetchFeedData(userName: username, userToken: userToken)
+      .receive(on: DispatchQueue.main)
+      .sink(receiveCompletion: { completion in
+        switch completion {
+        case .finished:
+          break
+        case .failure(let error):
+          print("API Error: \(error)")
+        }
+      }, receiveValue: { data in
+        self.feedData = data
+        self.events = data.payload.events
+        if let firstEvent = self.events.first {
+          self.fetchCoverArt(for: firstEvent)
+        }
+      })
+      .store(in: &subscriptions)
+  }
 
-
-  func fetchFeedEvents(username: String,userToken:String) {
-        repository.fetchFeedData(userName: username,userToken: userToken)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case .finished:
-                    break
-                case .failure(let error):
-                    print("API Error: \(error)")
-                }
-            }, receiveValue: { data in
-                self.feedData = data
-                self.events = data.payload.events
-            })
-            .store(in: &subscriptions)
+  private func fetchCoverArt(for event: Event) {
+    guard let coverArtURL = event.metadata.trackMetadata?.coverArtURL else {
+      return
     }
-}
 
+    AF.request(coverArtURL, method: .get)
+      .validate()
+      .responseData { [weak self] response in
+        guard self != nil else { return }
+
+        switch response.result {
+        case .success(_):
+          print("Cover art fetched successfully")
+        case .failure(let error):
+          print("Error fetching cover art: \(error)")
+        }
+      }
+  }
+}

--- a/Listenbrainz/ViewModel/HomeViewModel.swift
+++ b/Listenbrainz/ViewModel/HomeViewModel.swift
@@ -51,45 +51,4 @@ class HomeViewModel: ObservableObject {
   }
 }
 
-class ImageCache {
-  static let shared = ImageCache()
 
-  private let cache = NSCache<NSURL, UIImage>()
-
-  func image(for url: URL) -> UIImage? {
-    return cache.object(forKey: url as NSURL)
-  }
-
-  func insertImage(_ image: UIImage, for url: URL) {
-    cache.setObject(image, forKey: url as NSURL)
-  }
-}
-
-class ImageLoader: ObservableObject {
-  static let shared = ImageLoader()
-
-  private var cancellables: Set<AnyCancellable> = []
-
-  @Published var imageCache: [URL: UIImage] = [:]
-
-  func loadImage(url: URL, completion: @escaping (UIImage?) -> Void) {
-    if let cachedImage = imageCache[url] {
-      completion(cachedImage)
-      return
-    }
-
-    AF.request(url).responseData { response in
-      switch response.result {
-      case .success(let data):
-        if let uiImage = UIImage(data: data) {
-          self.imageCache[url] = uiImage
-          completion(uiImage)
-        } else {
-          completion(nil)
-        }
-      case .failure:
-        completion(nil)
-      }
-    }
-  }
-}

--- a/Listenbrainz/ViewModel/HomeViewModel.swift
+++ b/Listenbrainz/ViewModel/HomeViewModel.swift
@@ -5,38 +5,91 @@
 //  Created by Gaurav Bhardwaj on 29/05/23.
 //
 
-import Foundation
+import SwiftUI
 import Combine
+import Alamofire
+
+class HomeViewModel: ObservableObject {
+  @Published var listens: [Listen] = []
+  private var subscriptions: Set<AnyCancellable> = []
+  var repository: HomeRepository
+
+  init(repository: HomeRepository) {
+    self.repository = repository
+  }
+
+  func requestMusicData(userName: String) {
+    repository.fetchMusicData(userName: userName)
+      .receive(on: DispatchQueue.main)
+      .sink(receiveCompletion: { completion in
+        print(completion)
+      }, receiveValue: { value in
+        self.listens = value.payload.listens
+        if let firstListen = self.listens.first,
+           let coverArtURL = firstListen.trackMetadata.coverArtURL {
+          self.fetchCoverArt(url: coverArtURL) { result in
+            switch result {
+            case .success(_):
+              print("Cover art fetched successfully")
+            case .failure(let error):
+              print("Error fetching cover art: \(error)")
+            }
+          }
+        }
+      })
+      .store(in: &subscriptions)
+  }
 
 
-class HomeViewModel : ObservableObject {
 
-    @Published var listens: [Listen] = []
-
-
-    private var subscriptions: Set<AnyCancellable> = []
-
-    var repository: HomeRepository
-
-
-    init(repository: HomeRepository) {
-        self.repository = repository
-
-    }
-
-
-
-  func requestMusicData(userName:String) {
-      repository.fetchMusicData(userName: userName)
-            .receive(on: DispatchQueue.main)
-            .sink(receiveCompletion: { completion in
-                print(completion)
-            }, receiveValue: { value in
-              self.listens = value.payload.listens
-            })
-            .store(in: &subscriptions)
-    }
+  private func fetchCoverArt(url: URL, completion: @escaping (Result<Data, AFError>) -> Void) {
+    AF.request(url, method: .get)
+      .validate()
+      .responseData { response in
+        completion(response.result)
+      }
+  }
 }
 
+class ImageCache {
+  static let shared = ImageCache()
 
+  private let cache = NSCache<NSURL, UIImage>()
 
+  func image(for url: URL) -> UIImage? {
+    return cache.object(forKey: url as NSURL)
+  }
+
+  func insertImage(_ image: UIImage, for url: URL) {
+    cache.setObject(image, forKey: url as NSURL)
+  }
+}
+
+class ImageLoader: ObservableObject {
+  static let shared = ImageLoader()
+
+  private var cancellables: Set<AnyCancellable> = []
+
+  @Published var imageCache: [URL: UIImage] = [:]
+
+  func loadImage(url: URL, completion: @escaping (UIImage?) -> Void) {
+    if let cachedImage = imageCache[url] {
+      completion(cachedImage)
+      return
+    }
+
+    AF.request(url).responseData { response in
+      switch response.result {
+      case .success(let data):
+        if let uiImage = UIImage(data: data) {
+          self.imageCache[url] = uiImage
+          completion(uiImage)
+        } else {
+          completion(nil)
+        }
+      case .failure:
+        completion(nil)
+      }
+    }
+  }
+}


### PR DESCRIPTION
### What's new?

- Add cover art Urls in feed and listen trackmetadata.
- Add functions for fetching cover-arts in viewmodels.
- Using these functions to show cover-arts in UI.
- Implement Caching so that images don't refresh again and again.
- Minor UX fixes for the feed